### PR TITLE
Display the time of the last rating

### DIFF
--- a/app/Http/Resources/PackageResource.php
+++ b/app/Http/Resources/PackageResource.php
@@ -32,6 +32,7 @@ class PackageResource extends ModelResource
             'url' => $package->url,
             'average_rating' => $this->averageRating($package),
             'rating_count' => $this->ratingCount($package),
+            'last_rated_at' => $package->loadMissing('ratings')->ratings->sortByDesc('updated_at')->first()['updated_at'],
             'created_at' => $package->created_at->diffForHumans(),
             'is_favorite' => $this->isFavorite($package),
             'favorites_count' => $this->favoritesCount($package),

--- a/resources/assets/js/components/PackageDetailFrame.vue
+++ b/resources/assets/js/components/PackageDetailFrame.vue
@@ -364,8 +364,14 @@
                         v-for="rating_count in package.rating_counts"
                     />
 
-                    <div class="text-right text-sm text-grey-dark mt-2 mb-2">
+                    <div class="text-right text-sm text-grey-dark mt-2">
                         {{ totalRatings }} ratings
+                    </div>
+
+                    <div v-if="package.last_rated_at" class="text-right text-sm text-grey-dark mb-2">
+                        <span :title="lastRatedTitle">
+                            {{ lastRatedAtString }}
+                        </span>
                     </div>
 
                     <div v-if="auth && !package.current_user_review.length">
@@ -507,6 +513,20 @@ export default {
 
         packagistDownloads: function() {
             return this.package.packagist_downloads.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+        },
+
+        lastRatedAtString: function() {
+            return this.package.last_rated_at ? 'Last rated ' + moment(this.package.last_rated_at).fromNow() : null;
+        },
+
+        lastRatedTitle: function() {
+            if (!this.package.last_rated_at) {
+                return null;
+            }
+
+            let momented = moment(this.package.last_rated_at)
+
+            return momented.format('MMMM Do, YYYY') + ' at ' + momented.format('h:mma');
         },
     },
 


### PR DESCRIPTION
This PR displays the date of the last rating so users can get an idea if the ratings for a package are fresh or not.

Example 1:
![image](https://user-images.githubusercontent.com/1141514/73315560-3de5ad80-41e5-11ea-894e-699572a6e61f.png)

Example 2:
![image](https://user-images.githubusercontent.com/1141514/73315611-67063e00-41e5-11ea-866f-db5e4a863f87.png)

Example 3 shows how the `title` attribute provides a more detailed date and time:
![2020-01-28 15 34 10](https://user-images.githubusercontent.com/1141514/73315680-94eb8280-41e5-11ea-8b5c-98607e174af8.gif)

---

One thing I'm not sure about: I think it might be beneficial to move `$package->loadMissing('ratings')` to the beginning of the `toArray` function since the `ratings` relation is used in multiple places...

Any thoughts?

---

Fixes #6 