### PR TITLE
Updates ReadMe to include more project setup detail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,9 +7,14 @@
 
 ## Setting up Scout
 
-1. Make a new Algolia app
-2. Put its key and ID into your `.env`
-3. `php artisan scout:import "App\Package"`
+1. Make a new [Algolia app](https://www.algolia.com/)
+2. From your Algolia app, copy the Admin API key and ID into your `.env`. If you see a "Not enough rights to update an object near line:1 error when seeding your database, you're using the Search-Only key—swap it out for the Admin key.
+3. In your Algolia app, create a new index called "packages".
+4. After seeding your database, run `php artisan scout:import "App\Package"`
+
+## Seeding the Database
+
+1. `php artisan db:seed`
 
 ## Setting up GitHub Authentication
 
@@ -21,7 +26,7 @@
 
 1. Add the `SLACK_URL` variable to your `.env` to post to a Slack channel of your choosing.
 
-**Note:** This webhook is hit when certain events are fired. If you are not testing this webhook specifically, you may want to consider commenting it out to avoid sending unnecessary Slack notifications. 
+**Note:** This webhook is hit when certain events are fired. If you are not testing this webhook specifically, you may want to consider commenting it out to avoid sending unnecessary Slack notifications.
 
 ## Setting up the Filesystem for Screenshots
 
@@ -29,7 +34,7 @@
 
 ## Testing
 
-The tests in `tests/Feature/RepoTest.php` provide coverage for the readme import feature. These tests depend on an active Internet connection and will run by default. For convenience, they have been added to the `integration` group. If you would like to exlude these tests from running, you may do so by using phpunit's `--exclude-group` option 
+The tests in `tests/Feature/RepoTest.php` provide coverage for the readme import feature. These tests depend on an active Internet connection and will run by default. For convenience, they have been added to the `integration` group. If you would like to exlude these tests from running, you may do so by using phpunit's `--exclude-group` option
 
 
 ```

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ## Setting up Scout
 
 1. Make a new [Algolia app](https://www.algolia.com/)
-2. From your Algolia app, copy the Admin API key and ID into your `.env`. If you see a "Not enough rights to update an object near line:1 error when seeding your database, you're using the Search-Only key—swap it out for the Admin key.
+2. From your Algolia app, copy the Admin API key and ID into your `.env`. If you see a "Not enough rights to update an object near line:1" error when seeding your database, you're using the Search-Only key—swap it out for the Admin key.
 3. In your Algolia app, create a new index called "packages".
 4. After seeding your database, run `php artisan scout:import "App\Package"`
 


### PR DESCRIPTION
On the way to working on issue #54, I saw an opportunity to add some additional ReadMe detail to reflect Algolia's current app-creation process. Hopefully, this will save future contributors a few minutes of trial-and-error when installing locally.