### PR TITLE
Update GitHub Action keys to Laravel 8

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -7,7 +7,7 @@ on:
       - master
 jobs:
   test:
-    name: PHP 7.3, Laravel 6.*
+    name: PHP 7.3, Laravel 8.*
     runs-on: ubuntu-latest
 
     steps:
@@ -23,8 +23,8 @@ jobs:
         uses: actions/cache@v1
         with:
           path: ~/.composer/cache/files
-          key: php-7.3-laravel-6.*-composer-${{ hashFiles('**/composer.lock') }}
-          restore-keys: php-7.3-laravel-6.*-composer-
+          key: php-7.3-laravel-8.*-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: php-7.3-laravel-8.*-composer-
 
       - name: Cache npm dependencies
         uses: actions/cache@v1


### PR DESCRIPTION
Tiny PR to update our GitHub action to the new Laravel version.