### PR TITLE
Restyle flash status messages via new component

### DIFF
--- a/resources/views/admin.blade.php
+++ b/resources/views/admin.blade.php
@@ -8,11 +8,7 @@
                 Admin Dashboard
             </div>
             <div class="bg-white p-3 rounded-b">
-                @if (session('status'))
-                    <div class="bg-green-100 border border-green-300 text-green-600 text-sm px-4 py-3 rounded mb-4">
-                        {{ session('status') }}
-                    </div>
-                @endif
+                <x-status class="mb-4"/>
 
                 <p class="text-gray-600 text-sm">
                     Admin stuff here

--- a/resources/views/components/status.blade.php
+++ b/resources/views/components/status.blade.php
@@ -1,0 +1,5 @@
+@if (session('status'))
+    <div {{ $attributes->merge(['class' => 'bg-green-100 border border-green-300 text-green-600 text-sm px-4 py-3 rounded']) }}>
+        {{ session('status') }}
+    </div>
+@endif

--- a/resources/views/packages/index.blade.php
+++ b/resources/views/packages/index.blade.php
@@ -14,14 +14,10 @@
 @endsection
 
 @section('content')
+    <x-status class="container mx-auto mb-10"/>
     <div class="container mx-auto mb-4">
         <img src="/images/hero.svg" alt="Laravel Nova hero" class="w-full md:w-2/3 lg:w-1/2 mx-auto block">
     </div>
-    @if (session('status'))
-    <div class="bg-green-100 border border-green-300 text-green-600 text-sm px-4 py-3 rounded mb-4">
-        {{ session('status') }}
-    </div>
-    @endif
 
     @livewire('package-list')
 @endsection

--- a/resources/views/packages/show.blade.php
+++ b/resources/views/packages/show.blade.php
@@ -15,11 +15,7 @@
 @endsection
 
 @section('content')
-    @if (session('status'))
-        <div class="px-4 py-3 mb-4 text-sm text-green-600 bg-green-100 border border-green-300 rounded">
-            {{ session('status') }}
-        </div>
-    @endif
+    <x-status class="container mx-auto mb-4"/>
 
     <package-detail-frame
         :auth="{{ auth()->check() ? 'true' : 'false' }}"

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -16,11 +16,7 @@
     <div class="container mx-auto mb-4">
         <img src="/images/hero.svg" alt="Laravel Nova hero" class="w-full md:w-2/3 lg:w-1/2 mx-auto block">
     </div>
-    @if (session('status'))
-        <div class="bg-green-100 border border-green-300 text-green-600 text-sm px-4 py-3 rounded mb-4">
-            {{ session('status') }}
-        </div>
-    @endif
+    <x-status/>
     <package-index
         :auth="{{ auth()->check() ? 'true' : 'false' }}"
         :type-tags="{{ json_encode($typeTags) }}"


### PR DESCRIPTION
This PR fixes #45 by creating a new blade component for displaying status messages.

Home page:
![package-index](https://user-images.githubusercontent.com/1141514/122970281-8d7cca00-d342-11eb-8755-a05543d37021.png)

Package show:
![package-show](https://user-images.githubusercontent.com/1141514/122970278-8ce43380-d342-11eb-8aa4-3eb7cf7d7546.png)

Admin dashboard:
![admin-dashboard](https://user-images.githubusercontent.com/1141514/122970275-8c4b9d00-d342-11eb-8060-18041f96344d.png)

(`Rerum necessitatibus labore voluptatem eligendi eum odio ipsum`?? I'm just using Matt's example message from the linked issue 😄 )

---


I've updated the `welcome` blade template but I don't think it is being used now. I'll confirm and follow up on that in a future PR.