### PR TITLE
Allow advanced syntax in searches

### DIFF
--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api;
 
+use Algolia\AlgoliaSearch\SearchIndex;
 use App\CacheKeys;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Package as PackageResource;
@@ -28,7 +29,10 @@ class SearchController extends Controller
     private function searchFor($q)
     {
         return Cache::remember(CacheKeys::packageSearchResults($q), self::CACHE_LENGTH, function () use ($q) {
-            return Package::search($q)->get()->load(['tags', 'author']);
+            return Package::search($q, function (SearchIndex $algolia, string $query, array $options) {
+                $options['advancedSyntax'] = true;
+                return $algolia->search($query, $options);
+            })->get()->load(['tags', 'author']);
         });
     }
 }

--- a/app/Http/Controllers/Api/SearchController.php
+++ b/app/Http/Controllers/Api/SearchController.php
@@ -30,8 +30,7 @@ class SearchController extends Controller
     {
         return Cache::remember(CacheKeys::packageSearchResults($q), self::CACHE_LENGTH, function () use ($q) {
             return Package::search($q, function (SearchIndex $algolia, string $query, array $options) {
-                $options['advancedSyntax'] = true;
-                return $algolia->search($query, $options);
+                return $algolia->search($query, array_merge($options, ['advancedSyntax' => true]));
             })->get()->load(['tags', 'author']);
         });
     }

--- a/app/Http/Livewire/PackageList.php
+++ b/app/Http/Livewire/PackageList.php
@@ -52,6 +52,8 @@ class PackageList extends Component
     {
         if ($this->search) {
             $packages = Package::search($this->search, function (SearchIndex $algolia, string $query, array $options) {
+                $options['advancedSyntax'] = true;
+
                 if ($this->tag !== 'all') {
                     $options['tagFilters'] = [$this->tag];
                 }


### PR DESCRIPTION
This PR addresses the issue reported in #73 by enabling ["advanced syntax"](https://www.algolia.com/doc/api-reference/api-parameters/advancedSyntax/) when performing Algolia searches on the website and via the API.