### PR TITLE
Convert Popular Section

### DIFF
--- a/app/Http/Livewire/PackageList.php
+++ b/app/Http/Livewire/PackageList.php
@@ -63,7 +63,18 @@ class PackageList extends Component
 
             $packages->load(['author', 'ratings']);
         } else {
-            $packages = $this->tag === 'all' ? Package::query() : Package::tagged($this->tag);
+            switch ($this->tag) {
+                case 'all':
+                    $packages = Package::query();
+                    break;
+                case 'popular':
+                    $packages = Package::popular();
+                    break;
+                default:
+                    $packages = Package::tagged($this->tag);
+                    break;
+            }
+
             $packages = $packages->latest()->with(['author', 'ratings'])->paginate($this->pageSize);
         }
 

--- a/resources/views/livewire/partials/package-list-tags.blade.php
+++ b/resources/views/livewire/partials/package-list-tags.blade.php
@@ -8,6 +8,10 @@
                 All Packages
             </option>
 
+            <option value="popular">
+                Popular Packages
+            </option>
+
             <optgroup label="Package types">
                 @foreach ($typeTags as $thisTag)
                     <option value="{{ $thisTag->slug }}">{{ $thisTag->name }}</option>
@@ -36,6 +40,11 @@
                 wire:click="filterTag('all')"
                 class="block px-8 py-2 cursor-pointer hover:text-indigo-700 {{ $tag === 'all' ? 'text-gray-800 font-bold' : 'text-gray-700' }}"
                 >All packages</a>
+
+                <a
+                wire:click="filterTag('popular')"
+                class="block px-8 py-2 cursor-pointer hover:text-indigo-700 {{ $tag === 'popular' ? 'text-gray-800 font-bold' : 'text-gray-700' }}"
+                >Popular packages</a>
 
             <span class="block mt-4 mb-2 mx-4 pb-2 px-4 mt-6 border-b border-grey uppercase text-sm">Package types</span>
 

--- a/resources/views/livewire/popular-and-recent-packages.blade.php
+++ b/resources/views/livewire/popular-and-recent-packages.blade.php
@@ -16,7 +16,7 @@
             @include('livewire.partials.package-card', ['context' => 'popular'])
         @endforeach
 
-        <a href="#" wire:click.prevent="filterTag('popular')" class="text-indigo-600 underline font-bold ml-2 mb-6">See More...</a>
     </div>
+    <a href="#" wire:click.prevent="filterTag('popular')" class="text-indigo-600 underline font-bold ml-2 mb-6">See More...</a>
 </div>
 @endsection

--- a/resources/views/livewire/popular-and-recent-packages.blade.php
+++ b/resources/views/livewire/popular-and-recent-packages.blade.php
@@ -16,7 +16,7 @@
             @include('livewire.partials.package-card', ['context' => 'popular'])
         @endforeach
 
-        {!! $popularPackages->links() !!}
+        <a href="#" wire:click.prevent="filterTag('popular')" class="text-indigo-600 underline font-bold ml-2 mb-6">See More...</a>
     </div>
 </div>
 @endsection


### PR DESCRIPTION
# Summary
This pull request converts the popular section on the main page to resemble the "recent" section above it by:
- removing pagination in favor of a see more link below the section
- creating a filtered page for popular packages only
- adding a filter link in the sidebar that jumps to the popular page

This pull request closes #49 

## Screenshot
#### New index page
![Screen Shot 2021-08-30 at 4 25 45 PM](https://user-images.githubusercontent.com/6867485/131408317-634c557e-69dd-4442-b516-55c3dc0f7547.png)

#### New popular filter page
![Screen Shot 2021-08-30 at 4 26 03 PM](https://user-images.githubusercontent.com/6867485/131408443-dd9000a9-f4ab-4c9d-b3df-82a2f65c20a8.png)
