### PR TITLE
Add missing foreign keys

### DIFF
--- a/database/migrations/2021_09_22_221231_add_foreign_keys_to_reviews_table.php
+++ b/database/migrations/2021_09_22_221231_add_foreign_keys_to_reviews_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeysToReviewsTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->foreign('user_id')->references('id')->on('users');
+            $table->foreign('package_id')->references('id')->on('packages');
+            $table->foreign('rating_id')->references('id')->on('ratings');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('reviews', function (Blueprint $table) {
+            $table->dropForeign([
+                'package_id',
+                'rating_id',
+                'user_id',
+            ]);
+        });
+    }
+}

--- a/database/migrations/2021_09_22_221244_add_foreign_keys_to_collaborator_package_table.php
+++ b/database/migrations/2021_09_22_221244_add_foreign_keys_to_collaborator_package_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddForeignKeysToCollaboratorPackageTable extends Migration
+{
+    public function up()
+    {
+        Schema::table('collaborator_package', function (Blueprint $table) {
+            $table->foreign('package_id')->references('id')->on('packages');
+            $table->foreign('collaborator_id')->references('id')->on('collaborators');
+        });
+    }
+
+    public function down()
+    {
+        Schema::table('collaborator_package', function (Blueprint $table) {
+            $table->dropForeign([
+                'package_id',
+                'collaborator_id',
+            ]);
+        });
+    }
+}


### PR DESCRIPTION
This PR adds foreign keys that are missing on the `reviews` and `collaborator_package` tables. This will prevent orphaned data in these tables when packages are deleted.