### PR TITLE
Fix rating count bar

### DIFF
--- a/resources/assets/js/components/RatingCountBar.vue
+++ b/resources/assets/js/components/RatingCountBar.vue
@@ -2,7 +2,7 @@
     <div class="flex my-1">
         <div class="w-1/3 text-xs pr-1 text-gray-500 text-right">{{ "".padStart(stars, "★") }}</div>
         <div class="w-2/3 w-full bg-gray-200 h-2 mt-1">
-            <div class="bg-yellow h-2" :style="`width: ${ percent }%`"></div>
+            <div class="bg-yellow-500 h-2" :style="`width: ${ percent }%`"></div>
         </div>
     </div>
 </template>


### PR DESCRIPTION
This is a tiny PR that fixes the rating bars so they actually display correctly.

Before:
![image](https://user-images.githubusercontent.com/1141514/135173213-e4abbbd1-1bad-4ff7-84cf-a5186f9b78e0.png)

After:
![image](https://user-images.githubusercontent.com/1141514/135173216-75a38818-37d0-4135-b1db-bea8c2825175.png)

There is more that can be done here but I'm holding on it because we'll be moving this over to Livewire in #42, #44, and #46.