### PR TITLE
Fix Collaborator select dropbox

### DIFF
--- a/app/Collaborator.php
+++ b/app/Collaborator.php
@@ -13,6 +13,8 @@ class Collaborator extends Model
 
     protected $casts = ['user_id' => 'integer'];
 
+    protected $appends = ['name_with_username'];
+
     public function allAuthoredPackages()
     {
         return $this->hasMany(Package::class, 'author_id')->withoutGlobalScope('notDisabled');
@@ -36,6 +38,15 @@ class Collaborator extends Model
     public function user()
     {
         return $this->belongsTo(User::class);
+    }
+
+    public function getnameWithUsernameAttribute()
+    {
+        if (! $this->github_username) {
+            return $this->name;
+        }
+
+        return "{$this->name} ({$this->github_username})";
     }
 
     public function getRouteKeyName()

--- a/public/js/resources_assets_js_components_CollaboratorSelect_vue.js
+++ b/public/js/resources_assets_js_components_CollaboratorSelect_vue.js
@@ -34,24 +34,8 @@ __webpack_require__.r(__webpack_exports__);
   },
   data: function data() {
     return {
-      selected: this.initialSelected || (this.multiple ? [] : null),
-      useCollaborators: []
+      selected: this.initialSelected || (this.multiple ? [] : null)
     };
-  },
-  mounted: function mounted() {
-    this.useCollaborators = this.collaborators.map(function (collaborator) {
-      collaborator.labelName = "".concat(collaborator.name, " (").concat(collaborator.github_username, ")");
-      return collaborator;
-    });
-
-    if (this.multiple) {
-      this.selected = this.selected.map(function (collaborator) {
-        collaborator.labelName = "".concat(collaborator.name, " (").concat(collaborator.github_username, ")");
-        return collaborator;
-      });
-    } else {
-      this.$set(this.selected, 'labelName', "".concat(this.selected.name, " (").concat(this.selected.github_username, ")"));
-    }
   }
 });
 
@@ -153,7 +137,7 @@ var render = function () {
         attrs: {
           multiple: _vm.multiple,
           options: _vm.collaborators,
-          label: "labelName",
+          label: "name_with_username",
           inputId: "collaborators",
         },
         model: {

--- a/resources/assets/js/components/CollaboratorSelect.vue
+++ b/resources/assets/js/components/CollaboratorSelect.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <v-select class="mb-4" :multiple="multiple" v-model="selected" :options="collaborators" label="labelName" inputId="collaborators"></v-select>
+        <v-select class="mb-4" :multiple="multiple" v-model="selected" :options="collaborators" label="name_with_username" inputId="collaborators"></v-select>
         <input v-if="multiple" v-for="collaborator in selected" type="hidden" :name="`${name}[]`" :value="collaborator.id" />
         <input v-if="! multiple" type="hidden" :name="`${name}`" :value="selected ? selected.id : null" />
     </div>
@@ -17,25 +17,7 @@ export default {
     data: function() {
         return {
             selected: this.initialSelected || (this.multiple ? [] : null),
-            useCollaborators: [],
         };
     },
-    mounted: function() {
-        this.useCollaborators = this.collaborators.map((collaborator) => {
-            collaborator.labelName = `${collaborator.name} (${collaborator.github_username})`;
-
-            return collaborator;
-        });
-
-        if (this.multiple) {
-            this.selected = this.selected.map((collaborator) => {
-                collaborator.labelName = `${collaborator.name} (${collaborator.github_username})`;
-
-                return collaborator;
-            });
-        } else {
-            this.$set(this.selected, 'labelName', `${this.selected.name} (${this.selected.github_username})`);
-        }
-    }
 };
 </script>

--- a/tests/Unit/CollaboratorTest.php
+++ b/tests/Unit/CollaboratorTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Collaborator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CollaboratorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    function name_with_username_attribute()
+    {
+        $this->assertEquals(
+            'Ted Lasso (tedlasso)',
+            Collaborator::factory()->create([
+                'name' => 'Ted Lasso',
+                'github_username' => 'tedlasso',
+            ])->name_with_username
+        );
+
+        $this->assertEquals(
+            'Ted Lasso',
+            Collaborator::factory()->create([
+                'name' => 'Ted Lasso',
+                'github_username' => null,
+            ])->name_with_username
+        );
+    }
+}


### PR DESCRIPTION
As mentioned in #173, the collaborator select box is broken.

The issue is that the `labelName` attribute that should be added in the `mounted` method of `CollaboratorSelect` was not always doing so.

I solved this by adding an accessor to the Collaborator model that does the concatenation in a simpler method and has the `CollaboratorSelect` use it.

---

Closes #173 