### PR TITLE
Add providers column to oauth_clients table

### DIFF
--- a/database/migrations/2022_02_04_220040_add_providers_column_to_oauth_clients_table.php
+++ b/database/migrations/2022_02_04_220040_add_providers_column_to_oauth_clients_table.php
@@ -1,0 +1,25 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProvidersColumnToOauthClientsTable extends Migration
+{
+    public function up()
+    {
+        if (! Schema::hasColumn('oauth_clients', 'provider')) {
+            Schema::table('oauth_clients', function (Blueprint $table) {
+                // https://github.com/laravel/passport/blob/master/UPGRADE.md#support-for-multiple-guards
+                $table->string('provider')->after('secret')->nullable();
+            });
+        }
+    }
+
+    public function down()
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
It looks like we missed a step when upgrading Passport in the past. This PR adds a migration to add the `provider` column to the `oauth_clients` table if it does not already exist.

https://github.com/laravel/passport/blob/master/UPGRADE.md#support-for-multiple-guards