### PR TITLE
Require PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "license": "MIT",
     "type": "project",
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.0",
         "algolia/algoliasearch-client-php": "^3.2",
         "bugsnag/bugsnag-laravel": "^2.23",
         "doctrine/dbal": "^3.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "94c48d28a0bc7fc89a0851a1b4889e5b",
+    "content-hash": "ee5ba34ca29a752bad629a1bfc339670",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -12081,7 +12081,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.4|^8.0"
+        "php": "^8.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"


### PR DESCRIPTION
This PR ensures that the application can only be installed in environments running PHP 8.0 and above.