### PR TITLE
Fix screenshot uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laravel/scout": "^9.4",
         "laravel/slack-notification-channel": "^2.4",
         "laravel/socialite": "^5.5",
-        "laravel/telescope": "^4.8",
+        "laravel/telescope": "4.8.1",
         "laravel/tinker": "^2.5",
         "laravel/ui": "^3.4",
         "laravelium/sitemap": "^8.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee5ba34ca29a752bad629a1bfc339670",
+    "content-hash": "2fd41bf5ca23f4f74cbb9ad77f490b86",
     "packages": [
         {
             "name": "algolia/algoliasearch-client-php",
@@ -2668,16 +2668,16 @@
         },
         {
             "name": "laravel/telescope",
-            "version": "v4.8.3",
+            "version": "v4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/telescope.git",
-                "reference": "bb23d58161032c8745d38348452afcbcd8adfc78"
+                "reference": "2c61ad4a1d1366f2829cbe3d50d004cef7dfc691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/telescope/zipball/bb23d58161032c8745d38348452afcbcd8adfc78",
-                "reference": "bb23d58161032c8745d38348452afcbcd8adfc78",
+                "url": "https://api.github.com/repos/laravel/telescope/zipball/2c61ad4a1d1366f2829cbe3d50d004cef7dfc691",
+                "reference": "2c61ad4a1d1366f2829cbe3d50d004cef7dfc691",
                 "shasum": ""
             },
             "require": {
@@ -2730,9 +2730,9 @@
             ],
             "support": {
                 "issues": "https://github.com/laravel/telescope/issues",
-                "source": "https://github.com/laravel/telescope/tree/v4.8.3"
+                "source": "https://github.com/laravel/telescope/tree/v4.8.1"
             },
-            "time": "2022-04-11T14:29:02+00:00"
+            "time": "2022-03-26T16:04:21+00:00"
         },
         {
             "name": "laravel/tinker",


### PR DESCRIPTION
This PR pins Telescope to `v4.8.1`. It seems that [`v4.8.2`](https://github.com/laravel/telescope/releases/tag/v4.8.2) introduced an issue in our production environment. Thanks to [this comment](https://github.com/laravel/telescope/issues/289#issuecomment-1106588118) on an issue point me in the right direction.

The issue we were experiencing is that adding screenshots via the drag and drop box on the edit package page was returning the id of the uploaded screenshots as `0` which was subsequently passed along when the user hit the Save button.

Closes #203 