### PR TITLE
Minor updates to code style

### DIFF
--- a/app/Console/Commands/DeleteSelfAuthoredPackageRatings.php
+++ b/app/Console/Commands/DeleteSelfAuthoredPackageRatings.php
@@ -19,7 +19,7 @@ class DeleteSelfAuthoredPackageRatings extends Command
 
     private function deleteSelfAuthoredPackageRatings()
     {
-        $query = Rating::whereHasMorph('rateable', 'App\Package', function ($query) {
+        $query = Rating::whereHasMorph('rateable', \App\Package::class, function ($query) {
             return $query
                 ->join('collaborators', 'collaborators.id', '=', 'packages.author_id')
                 ->whereRaw('collaborators.user_id = ratings.user_id');
@@ -32,7 +32,7 @@ class DeleteSelfAuthoredPackageRatings extends Command
 
     private function deleteSelfContributedPackageRatings()
     {
-        $query = Rating::whereHasMorph('rateable', 'App\Package', function ($query) {
+        $query = Rating::whereHasMorph('rateable', \App\Package::class, function ($query) {
             return $query
                 ->join('collaborator_package', 'collaborator_package.package_id', '=', 'packages.id')
                 ->join('collaborators', 'collaborators.id', '=', 'collaborator_package.collaborator_id')

--- a/app/Console/Commands/DisableUnavailablePackages.php
+++ b/app/Console/Commands/DisableUnavailablePackages.php
@@ -21,7 +21,9 @@ class DisableUnavailablePackages extends Command
 
         $unavailablePackages->each(function ($package) {
             $diffInDays = now()->diffInDays($package->marked_as_unavailable_at);
-            if ($diffInDays < 30) return;
+            if ($diffInDays < 30) {
+                return;
+            }
 
             $package->is_disabled = 1;
             $package->save();

--- a/app/Console/Commands/SendUnavailablePackageFollowUp.php
+++ b/app/Console/Commands/SendUnavailablePackageFollowUp.php
@@ -19,9 +19,11 @@ class SendUnavailablePackageFollowUp extends Command
             ->where('is_disabled', 0)
             ->get();
 
-        $unavailablePackages->each(function($package) {
+        $unavailablePackages->each(function ($package) {
             $diffInDays = now()->diffInDays($package->marked_as_unavailable_at);
-            if ($diffInDays != 14) return;
+            if ($diffInDays != 14) {
+                return;
+            }
 
             if ($package->author && $package->authorIsUser()) {
                 $package->author->user->notify(new RemindAuthorOfUnavailablePackage($package));

--- a/app/Http/Resources/PackageDetailResource.php
+++ b/app/Http/Resources/PackageDetailResource.php
@@ -92,7 +92,7 @@ class PackageDetailResource extends PackageResource
         $key = CacheKeys::userPackageRating(auth()->id(), $package->id);
 
         return Cache::remember($key, self::CACHE_RATINGS_LENGTH, function () use ($package) {
-            return (int)$package->user_average_rating;
+            return (int) $package->user_average_rating;
         });
     }
 

--- a/app/Jobs/CheckPackageUrlsForAvailability.php
+++ b/app/Jobs/CheckPackageUrlsForAvailability.php
@@ -35,7 +35,9 @@ class CheckPackageUrlsForAvailability implements ShouldQueue
             $urlIsValid = false; // If we can't reach the domain at all, mark as invalid
         }
 
-        if ($urlIsValid) return;
+        if ($urlIsValid) {
+            return;
+        }
 
         $this->package->marked_as_unavailable_at = now();
         $this->package->save();

--- a/app/Jobs/SyncPackagePackagistData.php
+++ b/app/Jobs/SyncPackagePackagistData.php
@@ -51,7 +51,7 @@ class SyncPackagePackagistData implements ShouldQueue
 
                 if (strlen($novaVersion) > 0) {
                     $novaVersion = substr($novaVersion, 0, 1);
-                }else {
+                } else {
                     $novaVersion = null;
                 }
             }

--- a/app/Listeners/PackageEventSubscriber.php
+++ b/app/Listeners/PackageEventSubscriber.php
@@ -18,12 +18,12 @@ class PackageEventSubscriber
     public function subscribe($events)
     {
         $events->listen(
-            'App\Events\PackageCreated',
+            \App\Events\PackageCreated::class,
             'App\Listeners\PackageEventSubscriber@handle'
         );
 
         $events->listen(
-            'App\Events\PackageUpdated',
+            \App\Events\PackageUpdated::class,
             'App\Listeners\PackageEventSubscriber@handle'
         );
     }

--- a/app/Notifications/ApologizeForIncorrectGitHubDisconnect.php
+++ b/app/Notifications/ApologizeForIncorrectGitHubDisconnect.php
@@ -19,7 +19,7 @@ class ApologizeForIncorrectGitHubDisconnect extends Notification implements Shou
     public function toMail($notifiable)
     {
         return (new MailMessage)
-            ->subject("Our apologies for the incorrect error email!")
+            ->subject('Our apologies for the incorrect error email!')
             ->line("Yesterday you received an email from NovaPackages saying your package's URL can't be reached. However, this was due to an overeager notification script that didn't consider GitHub's rate limiting.")
             ->line("We've disabled that script until we can help it grow up a little. Sorry for the inconvenience!")
             ->line("If you'd like, you can log into Nova Packages now to view or edit any of your packages:")

--- a/app/NpmRepo.php
+++ b/app/NpmRepo.php
@@ -65,7 +65,7 @@ class NpmRepo extends BaseRepo
 
     public function latestReleaseVersion()
     {
-        return optional($this->repo)->latestReleaseVersion() ?? 'master';
+        return $this->repo?->latestReleaseVersion() ?? 'master';
     }
 
     public function readme()

--- a/app/Package.php
+++ b/app/Package.php
@@ -197,7 +197,9 @@ class Package extends Model implements Feedable
 
     public function updateAvailabilityFromNewUrl()
     {
-        if (is_null($this->marked_as_unavailable_at)) return;
+        if (is_null($this->marked_as_unavailable_at)) {
+            return;
+        }
 
         if (array_key_exists('url', $this->getChanges())) {
             $this->marked_as_unavailable_at = null;

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -40,11 +40,11 @@ class RouteServiceProvider extends ServiceProvider
 
         Route::bind('any_package', function ($id) {
 
-            if (optional(auth()->user())->isAdmin()) {
+            if (auth()->user()?->isAdmin()) {
                 return Package::withoutGlobalScope('notDisabled')->findOrFail($id);
             }
 
-            if (optional(auth()->user())->isPackageAuthor($id)) {
+            if (auth()->user()?->isPackageAuthor($id)) {
                 return Package::withoutGlobalScope('notDisabled')->findOrFail($id);
             }
 

--- a/app/User.php
+++ b/app/User.php
@@ -88,7 +88,7 @@ class User extends Authenticatable
 
     public function isPackageAuthor($packageId)
     {
-        return $this->collaborators->contains(function($collaborator) use ($packageId) {
+        return $this->collaborators->contains(function ($collaborator) use ($packageId) {
             return $collaborator->allAuthoredPackages->contains('id', $packageId);
         });
     }

--- a/database/factories/CollaboratorFactory.php
+++ b/database/factories/CollaboratorFactory.php
@@ -22,10 +22,10 @@ class CollaboratorFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->firstName.' '.$this->faker->lastName,
-            'url' => $this->faker->url,
+            'name' => $this->faker->firstName().' '.$this->faker->lastName(),
+            'url' => $this->faker->url(),
             'description' => implode(' ', $this->faker->sentences(2))."\n\n".implode(' ', $this->faker->sentences(2)),
-            'github_username' => $this->faker->slug,
+            'github_username' => $this->faker->slug(),
         ];
     }
 }

--- a/database/factories/PackageFactory.php
+++ b/database/factories/PackageFactory.php
@@ -23,18 +23,18 @@ class PackageFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->sentence,
-            'url' => "{$this->faker->url}/{$this->faker->slug}",
+            'name' => $this->faker->sentence(),
+            'url' => "{$this->faker->url()}/{$this->faker->slug()}",
             'picture_url' => 'https://picsum.photos/380/220/?random',
             'description' => markdown('# '.$this->faker->sentence()."\n\n"
                 .implode(' ', $this->faker->sentences(2))."\n\n"
                 .implode(' ', $this->faker->sentences(4))),
             'instructions' => markdown('```'.implode(' ', $this->faker->sentences(4)).'```'),
             'author_id' => Collaborator::factory(),
-            'composer_name' => $this->faker->slug.'/'.$this->faker->slug,
+            'composer_name' => $this->faker->slug().'/'.$this->faker->slug(),
             'is_disabled' => false,
             'abstract' => $this->faker->text(190),
-            'readme' => markdown('# '.$this->faker->sentence."\n\n"
+            'readme' => markdown('# '.$this->faker->sentence()."\n\n"
                 .implode(' ', $this->faker->sentences(2))."\n\n"
                 .implode(' ', $this->faker->sentences(4))),
         ];

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -22,7 +22,7 @@ class TagFactory extends Factory
      */
     public function definition()
     {
-        $name = $this->faker->sentence;
+        $name = $this->faker->sentence();
 
         return [
             'name' => Str::lower($name),

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -23,10 +23,10 @@ class UserFactory extends Factory
     public function definition()
     {
         return [
-            'name' => $this->faker->name,
-            'email' => $this->faker->unique()->safeEmail,
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
             'remember_token' => Str::random(10),
-            'github_username' => $this->faker->userName,
+            'github_username' => $this->faker->userName(),
         ];
     }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -17,7 +17,7 @@
 
     <script>
         window.novapackages = {
-            is_admin: {{ optional(auth()->user())->isAdmin() ? "true" : "false" }},
+            is_admin: {{ auth()->user()?->isAdmin() ? "true" : "false" }},
             csrf_token: '{{ csrf_token() }}',
             user_id: '{{ auth()->id() ?? null }}'
         };

--- a/resources/views/livewire/partials/package-card.blade.php
+++ b/resources/views/livewire/partials/package-card.blade.php
@@ -4,7 +4,7 @@ $package['accent'] = app(App\Colors::class)->nextColor();
 @endphp
 <div class="flex m-2 mb-4 shadow hover:shadow-md h-128 w-full max-w-xs rounded relative" wire:key="{{ $context ?? 'no-context' }}-{{ $package['id'] }}">
     <div style="border: 1px solid #ddd; border-top-width: 4px; border-top-color: {{ $package['accent'] }}" class="flex-1 bg-white text-sm rounded">
-        @if (optional(auth()->user())->isAdmin())
+        @if (auth()->user()?->isAdmin())
             <div class="text-right -mb-6">
                 <div class="relative" x-data="{ open: false }">
                     <div role="button" class="inline-block select-none p-2" @click="open = !open">

--- a/tests/Feature/PackageEditTest.php
+++ b/tests/Feature/PackageEditTest.php
@@ -320,13 +320,13 @@ class PackageEditTest extends TestCase
         $existingTagB = Tag::factory()->create(['name' => 'test tag b', 'slug' => 'test-tag-b']);
 
         $response = $this->actingAs($user)->put(route('app.packages.update', $package), [
-            'name' => $this->faker->company,
+            'name' => $this->faker->company(),
             'author_id' => $user->id,
-            'url' =>  $this->faker->url,
-            'abstract' =>  $this->faker->sentence,
-            'instructions' => $this->faker->sentence,
-            'packagist_namespace' => $this->faker->word,
-            'packagist_name' => $this->faker->word,
+            'url' =>  $this->faker->url(),
+            'abstract' =>  $this->faker->sentence(),
+            'instructions' => $this->faker->sentence(),
+            'packagist_namespace' => $this->faker->word(),
+            'packagist_name' => $this->faker->word(),
             'tags-new' => [
                 'Test tag A',
                 'Test tag B',
@@ -349,13 +349,13 @@ class PackageEditTest extends TestCase
         $existingTag = Tag::factory()->create(['name' => 'test tag', 'slug' => 'test-tag']);
 
         $response = $this->actingAs($user)->put(route('app.packages.update', $package), [
-            'name' => $this->faker->company,
+            'name' => $this->faker->company(),
             'author_id' => $user->id,
-            'url' =>  $this->faker->url,
-            'abstract' =>  $this->faker->sentence,
-            'instructions' => $this->faker->sentence,
-            'packagist_namespace' => $this->faker->word,
-            'packagist_name' => $this->faker->word,
+            'url' =>  $this->faker->url(),
+            'abstract' =>  $this->faker->sentence(),
+            'instructions' => $this->faker->sentence(),
+            'packagist_namespace' => $this->faker->word(),
+            'packagist_name' => $this->faker->word(),
             'tags-new' => [
                 'Test tag',
                 'New Tag',
@@ -383,12 +383,12 @@ class PackageEditTest extends TestCase
         $package->save();
 
         $this->actingAs($user)->put(route('app.packages.update', $package), [
-            'name' => $this->faker->company,
+            'name' => $this->faker->company(),
             'author_id' => $user->id,
             'url' =>  $package->url,
-            'abstract' =>  $this->faker->sentence,
-            'packagist_namespace' => $this->faker->word,
-            'packagist_name' => $this->faker->word,
+            'abstract' =>  $this->faker->sentence(),
+            'packagist_namespace' => $this->faker->word(),
+            'packagist_name' => $this->faker->word(),
         ])
         ->assertRedirect(route('app.packages.index'));
 
@@ -406,12 +406,12 @@ class PackageEditTest extends TestCase
         $package->save();
 
         $this->actingAs($user)->put(route('app.packages.update', $package), [
-            'name' => $this->faker->company,
+            'name' => $this->faker->company(),
             'author_id' => $user->id,
-            'url' =>  $this->faker->url,
-            'abstract' =>  $this->faker->sentence,
-            'packagist_namespace' => $this->faker->word,
-            'packagist_name' => $this->faker->word,
+            'url' =>  $this->faker->url(),
+            'abstract' =>  $this->faker->sentence(),
+            'packagist_namespace' => $this->faker->word(),
+            'packagist_name' => $this->faker->word(),
         ])
             ->assertRedirect(route('app.packages.index'));
 


### PR DESCRIPTION
This PR applies the following automations from [Laravel Shift Workbench](https://laravelshift.com/workbench):
- Uses Laravel code style
- Uses `::class` constant where possible (`\App\Package::class` instead of `'App\Package'`)
- Converts calls to the `optional` helper to the nullsafe operator
- Uses faker methods instead of properties