### PR TITLE
Fix searching while 'Popular' or 'Nova 4' filters are applied

### DIFF
--- a/app/Http/Livewire/PackageList.php
+++ b/app/Http/Livewire/PackageList.php
@@ -54,7 +54,7 @@ class PackageList extends Component
             $packages = Package::search($this->search, function (SearchIndex $algolia, string $query, array $options) {
                 $options['advancedSyntax'] = true;
 
-                if ($this->tag !== 'all') {
+                if (! in_array($this->tag, ['all', 'popular', 'nova_current'])) {
                     $options['tagFilters'] = [$this->tag];
                 }
 

--- a/app/Http/Livewire/PackageList.php
+++ b/app/Http/Livewire/PackageList.php
@@ -61,31 +61,15 @@ class PackageList extends Component
                 return $algolia->search($query, $options);
             })->query(function (Builder $builder) {
                 // Ensure search results use the same query scopes as non-filtered results
-                switch ($this->tag) {
-                    case 'popular':
-                        return $builder->popular();
-                    case 'nova_current':
-                        return $builder->novaCurrent();
-                    default:
-                        return $builder;
-                }
+                return $builder->filter($this->tag);
             })->paginate($this->pageSize);
 
             $packages->load(['author', 'ratings']);
         } else {
-            switch ($this->tag) {
-                case 'all':
-                    $packages = Package::query();
-                    break;
-                case 'popular':
-                    $packages = Package::popular();
-                    break;
-                case 'nova_current':
-                    $packages = Package::novaCurrent();
-                    break;
-                default:
-                    $packages = Package::tagged($this->tag);
-                    break;
+            if (in_array($this->tag, ['all', 'popular', 'nova_current'])) {
+                $packages = Package::filter($this->tag);
+            } else {
+                $packages = Package::tagged($this->tag);
             }
 
             $packages = $packages->latest()->with(['author', 'ratings'])->paginate($this->pageSize);

--- a/app/Http/Livewire/PackageList.php
+++ b/app/Http/Livewire/PackageList.php
@@ -6,7 +6,7 @@ use Algolia\AlgoliaSearch\SearchIndex;
 use App\CacheKeys;
 use App\Package;
 use App\Tag;
-use Illuminate\Http\Request;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Cookie;
 use Livewire\Component;
@@ -59,6 +59,16 @@ class PackageList extends Component
                 }
 
                 return $algolia->search($query, $options);
+            })->query(function (Builder $builder) {
+                // Ensure search results use the same query scopes as non-filtered results
+                switch ($this->tag) {
+                    case 'popular':
+                        return $builder->popular();
+                    case 'nova_current':
+                        return $builder->novaCurrent();
+                    default:
+                        return $builder;
+                }
             })->paginate($this->pageSize);
 
             $packages->load(['author', 'ratings']);

--- a/app/Package.php
+++ b/app/Package.php
@@ -77,7 +77,7 @@ class Package extends Model implements Feedable
         return $this->hasMany(Favorite::class);
     }
 
-    public static function scopeFilter($query, string $tag)
+    public function scopeFilter($query, string $tag)
     {
         switch ($tag) {
             case 'popular':

--- a/app/Package.php
+++ b/app/Package.php
@@ -77,6 +77,18 @@ class Package extends Model implements Feedable
         return $this->hasMany(Favorite::class);
     }
 
+    public static function scopeFilter($query, string $tag)
+    {
+        switch ($tag) {
+            case 'popular':
+                return $query->popular();
+            case 'nova_current':
+                return $query->novaCurrent();
+            default:
+                return $query;
+        }
+    }
+
     public function scopeTagged($query, $tagSlug)
     {
         $query->whereHas('tags', function ($query) use ($tagSlug) {


### PR DESCRIPTION
This PR fixes a bug causing no search results to appear on the 'Popular' and 'Nova 4' pages.

There were two issues:
1. `popular` and `nova_current` aren't real tags, but rather placeholder filters, so no packages had them applied in Algolia (which is why there were no search results).

Solution: They're now excluded from the tag list we send to Algolia while searching.

2. `popular` and `nova_current` correspond to query scopes, which weren't being applied on the Algolia search results.

Solution: The new `filter($tag)` scope on Packages (naming suggestions welcome 😄) applies query scopes depending on these "tags", and is applied to Algolia search results (in addition to regular list queries).


<details>

<summary>Other considerations (click to expand)</summary>
<br>

- I debated just sending `popular` and `nova_current` tags to Algolia, but chose not to because 1) `popular` is just a sort, not a filter and 2) `nova_current` would require the index to be updated on every new Nova release.
- I debated sending a `nova_version` tag to Algolia instead, but that would still require custom Algolia handling logic and gets weird when many versions of Nova are involved (since we're only tracking the latest supported version).

</details>