### PR TITLE
Fix author select on edit package page

### DIFF
--- a/resources/views/app/packages/edit.blade.php
+++ b/resources/views/app/packages/edit.blade.php
@@ -30,7 +30,7 @@
                     <input name="packagist_name" placeholder="nova-stock-ticker" class="border border-gray-600 p-2 mb-6 w-64" value="{{ old('packagist_name', $package->composer_package) }}">
 
                     <label class="block font-bold">Package author*</label>
-                    <collaborator-select :collaborators="{{ $collaborators }}" :initial-selected="{{ old('selectedAuthor', $package->author) }}" name="author_id"></collaborator-select>
+                    <collaborator-select :collaborators="{{ $collaborators }}" :initial-selected="{{ old('selectedAuthor', json_encode($package->author)) }}" name="author_id"></collaborator-select>
 
                     <label class="block font-bold">Contributors</label>
                     <collaborator-select multiple :collaborators="{{ $collaborators }}" :initial-selected="{{ old('selectedCollaborators', $package->contributors) }}" name="contributors"></collaborator-select>


### PR DESCRIPTION
This PR fixes the author select on the edit package page. The `old()` helper's behavior changed in [Laravel 9.8.0](https://github.com/laravel/framework/releases/tag/v9.8.0) so that it was trying to access `$package->author-> selectedAuthor` instead of simply the package's author. We can pass the author properly by json encoding it.