### PR TITLE
Set project specific queue name

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -167,7 +167,7 @@ return [
     'defaults' => [
         'supervisor-1' => [
             'connection' => 'redis',
-            'queue' => ['default'],
+            'queue' => [env('REDIS_QUEUE', 'novapackages-default')],
             'balance' => 'simple',
             'processes' => 2,
             'tries' => 3,

--- a/config/queue.php
+++ b/config/queue.php
@@ -65,7 +65,7 @@ return [
         'redis' => [
             'driver' => 'redis',
             'connection' => 'default',
-            'queue' => env('REDIS_QUEUE', 'default'),
+            'queue' => env('REDIS_QUEUE', 'novapackages-default'),
             'retry_after' => 90,
             'block_for' => null,
             'after_commit' => false,


### PR DESCRIPTION
This PR explicitly sets the name for the Redis queue to be project specific.