### PR TITLE
Locally cache GitHub responses

### DIFF
--- a/app/GitHubRepo.php
+++ b/app/GitHubRepo.php
@@ -21,6 +21,8 @@ class GitHubRepo extends BaseRepo
 
     protected $repo;
 
+    private array $cachedResponses;
+
     private function __construct($url, GitHub $github)
     {
         if (! GitHub::validateUrl($url)) {
@@ -42,12 +44,12 @@ class GitHubRepo extends BaseRepo
 
     public function readme()
     {
-        return $this->github->readme("{$this->username}/{$this->repo}");
+        return $this->cached('readme', fn() => $this->github->readme("{$this->username}/{$this->repo}"));
     }
 
     public function releases()
     {
-        return collect($this->github->releases("{$this->username}/{$this->repo}"));
+        return $this->cached('releases', fn() => collect($this->github->releases("{$this->username}/{$this->repo}")));
     }
 
     public function latestRelease()
@@ -60,5 +62,18 @@ class GitHubRepo extends BaseRepo
         // For GitHub, we want the `tag_name` of the latest release (rather than the `name`)
         // in order to correctly format relative URLs in the readme
         return Arr::get($this->latestRelease(), 'tag_name', 'master');
+    }
+
+    private function cached(string $key, callable $callback)
+    {
+        if (isset($this->cachedResponses[$key])) {
+            return $this->cachedResponses[$key];
+        }
+
+        $result = $callback();
+
+        $this->cachedResponses[$key] = $result;
+
+        return $result;
     }
 }


### PR DESCRIPTION
This PR locally caches the readme and releases responses after they are fetched for the first time in an instance of the `GitHubRepo` class in order to reduce the amount of requests made to the GitHub api.

As an example of duplicated requests: in the `SyncPackageRepositoryData` job, a request is made to get the current readme and compares it to what we have locally. If it is different, the same request is made again to fetch the readme when updating the model. With this PR, the initial response is stored so we can avoid the second, duplicate, request.