### PR TITLE
Improve handling of missing Packagist packages

### DIFF
--- a/app/Http/Remotes/Packagist.php
+++ b/app/Http/Remotes/Packagist.php
@@ -33,7 +33,13 @@ class Packagist
     public function fetchData($name)
     {
         $this->data = Cache::remember(CacheKeys::packagistData($name), 5, function () use ($name) {
-            return Http::packagist()->get("{$this->url}.json")->json();
+            $response = Http::packagist()->get("{$this->url}.json");
+
+            if ($response->status() === 404) {
+                return null;
+            }
+
+            return $response->json();
         });
 
         if (Arr::get($this->data, 'status') === 'error') {


### PR DESCRIPTION
This PR explicitly returns `null` when a package does not exist on Packagist.

Follow up on #265 where this was happening implicitly and 404s were returning html.