### PR TITLE
Reduce remote sync interval

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -21,8 +21,9 @@ class Kernel extends ConsoleKernel
 
     protected function schedule(Schedule $schedule)
     {
-        $schedule->command('sync:packagist')->hourly();
-        $schedule->command('sync:repo')->hourlyAt(30);
+        $schedule->command('sync:packagist')->everyTwoHours();
+        // Every two hours at minute 30.
+        $schedule->command('sync:repo')->cron('30 */2 * * *');
         $schedule->command('purge:abandonedscreenshots')->dailyAt('1:00');
         $schedule->command('telescope:prune')->daily();
 


### PR DESCRIPTION
We are occasionally bumping up against GitHub's [secondary rate limits](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#secondary-rate-limits). This PR increases syncing interval for both Packagist and repository providers (GitHub, Bitbucket, GitLab, npm) from hourly to every two hours, reduces the amount of tries for the sync repository job to two, and pushes the retry out ten minutes in an effort to alleviate the issue.