### PR TITLE
Adds `packages.json` feed to API

### DIFF
--- a/app/Http/Controllers/Api/FeedController.php
+++ b/app/Http/Controllers/Api/FeedController.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Package;
+
+class FeedController extends Controller
+{
+    public function __invoke()
+    {
+        return cache()->remember('all-packages-as-json', 3600, function () {
+            return Package::query()
+                ->with(['tags', 'author'])
+                ->get()
+                ->map(function ($package) {
+                    return [
+                        'name' => $package->display_name,
+                        'author' => $package->author->name,
+                        'abstract' => $package->abstract,
+                        'url' => route('packages.show', [
+                            'namespace' => $package->composer_vendor,
+                            'name' => $package->composer_package,
+                        ]),
+                        'tags' => $package->tags->pluck('name'),
+                    ];
+                });
+        });
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,6 +8,8 @@ Route::get('recent', Api\RecentController::class)->middleware('throttle:60');
 Route::get('popular', Api\PopularController::class)->middleware('throttle:60')->name('api.popular-packages');
 Route::get('stats', Api\StatsController::class)->middleware('throttle:60');
 
+Route::get('packages.json', Api\FeedController::class)->middleware('throttle:60');
+
 Route::middleware('auth:api')->group(function () {
     Route::get('packages', Api\PackagesController::class);
 });

--- a/tests/Feature/Api/FeedApiTest.php
+++ b/tests/Feature/Api/FeedApiTest.php
@@ -4,13 +4,15 @@ namespace Tests\Feature\Api;
 
 use App\Package;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\Fluent\AssertableJson;
 use Tests\TestCase;
 
 class FeedApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function it_counts_packages()
+    /** @test */
+    public function ensures_packages_feed_response_code_and_structure()
     {
         Package::factory(5)->create();
 
@@ -18,6 +20,12 @@ class FeedApiTest extends TestCase
 
         $response
             ->assertStatus(200)
-            ->assertJsonCount(5);
+            ->assertJson(function (AssertableJson $json) {
+                $json
+                    ->count(5)
+                    ->first(function (AssertableJson $json) {
+                        $json->hasAll(['name', 'author', 'abstract', 'url', 'tags']);
+                    });
+            });
     }
 }

--- a/tests/Feature/Api/FeedApiTest.php
+++ b/tests/Feature/Api/FeedApiTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Tests\Feature\Api;
+
+use App\Package;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FeedApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testBasic()
+    {
+        Package::factory(5)->create();
+
+        $response = $this->get('/api/packages.json')->json();
+
+        $response
+            ->assertStatus(200)
+            ->assertJsonCount(5);
+    }
+}

--- a/tests/Feature/Api/FeedApiTest.php
+++ b/tests/Feature/Api/FeedApiTest.php
@@ -10,11 +10,11 @@ class FeedApiTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function testBasic()
+    public function it_counts_packages()
     {
         Package::factory(5)->create();
 
-        $response = $this->get('/api/packages.json')->json();
+        $response = $this->getJson('/api/packages.json');
 
         $response
             ->assertStatus(200)


### PR DESCRIPTION
As discussed in: #292 

Adds an API route `/api/packages.json` which returns a JSON feed for all available Nova Packages with some meta data. To be used in (for example) a Discord bot to easily find packages.