### PR TITLE
Update home route to `/` instead of `/home`

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -18,7 +18,7 @@ class RouteServiceProvider extends ServiceProvider
      *
      * @var string
      */
-    public const HOME = '/home';
+    public const HOME = '/';
 
     /**
      * Define your route model bindings, pattern filters, etc.


### PR DESCRIPTION
### Summary

When an already authenticated user hits the `/login/github` route, we redirect them to the home page. Right now, that's defined as `/home` which doesn't exist as a route, and so an exception is thrown. This PR updates the home route to `/` in the `RouteServiceProvider` to fix the issue.